### PR TITLE
[FEAT] google login 인가코드 & 토큰 발급

### DIFF
--- a/src/components/auth/GoogleAuthButton.tsx
+++ b/src/components/auth/GoogleAuthButton.tsx
@@ -5,7 +5,21 @@ import { getIcons } from '@/src/assets/icons/getIcons';
 function GoogleAuthButton() {
   const GoogleIcon = getIcons('GoogleLogo');
 
-  return <WhiteButton Icon={GoogleIcon}>Sign in using Google</WhiteButton>;
+  const handleGoogleLogin = () => {
+    const googleAuthUrl =
+      'https://accounts.google.com/o/oauth2/auth?' +
+      `client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&` +
+      `redirect_uri=${process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI}&` +
+      `response_type=code&` +
+      `scope=email profile`;
+    window.location.href = googleAuthUrl;
+  };
+
+  return (
+    <WhiteButton Icon={GoogleIcon} handleClick={handleGoogleLogin}>
+      Sign in using Google
+    </WhiteButton>
+  );
 }
 
 export default GoogleAuthButton;

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -1,9 +1,16 @@
-export interface ITokenResponse {
+export interface IKakaoToken {
   token_type: string;
   access_token: string;
   refresh_token: string;
   id_token: string;
   expires_in: number;
   refresh_token_expires_in: string;
+  scope: string;
+}
+export interface IGoogleToken {
+  token_type: string;
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
   scope: string;
 }

--- a/src/pages/api/auth/googlecheck.ts
+++ b/src/pages/api/auth/googlecheck.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { IGoogleToken } from '@/src/models/auth';
+
+// URLSearchParams type error를 위해 무조건적인 값임을 나타내기 위해 선언
+const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!;
+const clientSecret = process.env.GOOGLE_AUTH_CLIENT_SECRET!;
+const redirectUri = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI!;
+
+async function exchangeCodeForToken(code: string) {
+  const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      code: code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+      grant_type: 'authorization_code',
+    }),
+  });
+
+  const tokenData: IGoogleToken = await tokenResponse.json();
+  return tokenData;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { code } = req.query;
+
+  if (code && typeof code === 'string') {
+    try {
+      const tokenResponse = await exchangeCodeForToken(code);
+      console.log(tokenResponse);
+      res.redirect(302, 'http://localhost:3000');
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ error: '서버 오류가 발생했습니다.' });
+    }
+  } else {
+    res.status(400).json({ error: 'access_token이 전달되지 않았습니다.' });
+  }
+}

--- a/src/pages/api/auth/kakaocheck.ts
+++ b/src/pages/api/auth/kakaocheck.ts
@@ -1,16 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { ITokenResponse } from '@/src/models/auth';
+import { IKakaoToken } from '@/src/models/auth';
 
 async function getTokenFromKakao(authCode: string) {
   const tokenUrl = `https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id=${process.env.NEXT_PUBLIC_KAKAO_AUTH_KEY}&client_secret=${process.env.KAKAO_AUTH_SECRET_KEY}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI}&code=${authCode}`;
-  const response: ITokenResponse = await fetch(tokenUrl, {
+  const response: IKakaoToken = await fetch(tokenUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
   }).then(res => res.json());
   return response;
 }
 
-async function postTokenToServer(res: ITokenResponse) {
+async function postTokenToServer(res: IKakaoToken) {
   const response = await fetch('/api/user/signin/kakao', {
     method: 'POST',
     headers: {


### PR DESCRIPTION
<img width="550" alt="image" src="https://github.com/Hoodie-Project/frontend/assets/70371342/392c3416-3eb9-4ec8-9ae6-9ad4ee52c29a">

[Google oauth 설명서](https://developers.google.com/identity/protocols/oauth2/javascript-implicit-flow?hl=ko)
[사용자의 승인 작동 방식 설명서](https://developers.google.com/identity/oauth2/web/guides/how-user-authz-works?hl=ko)

구글 로그인 인가 코드 & 토큰 발급 확인되었습니다. 
### 사용자 리다이렉션 url 생성 -> response_type=code를 포함 -> 인증 코드 받기 위한 요청임
response_type=access_token을 포함하는 버전도 있는데, 이 버전은 해시(#)를 이용해서 엑세스 토큰을 받아옵니다. 이 방식은 서버 사이드에서는 접근이 불가능하고 클라이언트 사이드에서 토큰을 받아오는 작업을 해야합니다. 이 방식은 [암시적 흐름](https://developers.google.com/identity/oauth2/web/guides/how-user-authz-works?hl=ko#oauth_20_flows)이라고 합니다.

저는 인증 코드 흐름을 사용해서 승인 코드가 리다이렉트 URL의 query param으로 포함시켜 Next.js의 api routes를 이용하여 서버사이드에서 토큰을 받아오게끔 구현하였습니다. 