### PR TITLE
[FIX] calendar 버그 해결

### DIFF
--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -5,6 +5,8 @@
  * @returns targetMonth에 대한 달력 데이터를 배열형태로 리턴
  */
 export function changeDate(targetMonth: number, year: number): number[] {
+  // 월이 1부터 12까지만 허용하도록
+
   // 이전 달의 마지막 날짜와 요일
   const prevLastDate = new Date(year, targetMonth - 1, 0).getDate();
   const prevLastDay = new Date(year, targetMonth - 1, 0).getDay();
@@ -18,6 +20,17 @@ export function changeDate(targetMonth: number, year: number): number[] {
   const thisDates = Array.from({ length: thisLastDate }, (_, i) => i + 1);
   // 다음 달의 날짜들을 계산
   const nextDates = Array.from({ length: 6 - thisLastDay }, (_, i) => i + 1);
+
+  // 12월 이후 월은 1월로 처리
+  if (targetMonth > 12) {
+    targetMonth = 1;
+    year += 1;
+  }
+  // 1월 이전 월은 12월로 처리
+  if (targetMonth < 1) {
+    targetMonth = 12;
+    year -= 1;
+  }
 
   return [...prevDates, ...thisDates, ...nextDates];
 }

--- a/src/zustand/calendar.ts
+++ b/src/zustand/calendar.ts
@@ -8,10 +8,21 @@ export const useMonthlyCalendarStore = create<CalendarState>(set => ({
   totalDate: changeDate(new Date().getMonth() + 1, new Date().getFullYear()),
   today: new Date().getDate(),
   setMonth: (month: number) =>
-    set(state => ({
-      month,
-      totalDate: changeDate(month, state.year),
-    })),
+    set(state => {
+      if (month > 12) {
+        month = 1;
+        state.year += 1;
+      }
+      if (month < 1) {
+        month = 12;
+        state.year -= 1;
+      }
+      return {
+        ...state,
+        month,
+        totalDate: changeDate(month, state.year),
+      };
+    }),
   setYear: (year: number) =>
     set(state => ({
       year,


### PR DESCRIPTION
### AS-IS
12월 다음 월은 13, 14, 15월.... 이렇게 계속 증가했으며, 1월 이전 월은 0월 -1월 -2월 ... 이렇게 계속 감소했었습니다.

### TO-BE
12월 다음 월은 1월이 되어야하고, 년도도 +1되어야 합니다. 
1월 이전 월은 12월이 되어야하며, 년도는 -1되어야 합니다.

### 해결
월이 1부터 12까지만 허용하도록 하고, 12월 이후 월은 1월로 처리하고 년도는 +1, 1월 이전 월은 12월로 처리하고 년도는 -1 로직을 zustand와 util함수에 추가하였습니다.

<img width="742" alt="image" src="https://github.com/Hoodie-Project/frontend/assets/70371342/2cad4857-5a91-47f5-a79e-e1970ebb77e6">

<img width="881" alt="image" src="https://github.com/Hoodie-Project/frontend/assets/70371342/4b3e267b-e861-4705-9a65-acae758bb732">
